### PR TITLE
fix image publishing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,5 +52,5 @@ image-push:
 		--platform="${PLATFORMS}" \
 		--tag="${IMAGE}" --push
 
-release: build image-push
+release: image-push
 	@echo "Released image: ${IMAGE}"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,5 +7,5 @@ steps:
   entrypoint: make
   env:
   - REGISTRY=gcr.io/k8s-staging-networking
-  - IMAGE_NAME=kube-network-policies
+  - IMAGE_NAME=kindnet
   args: ['release']


### PR DESCRIPTION
There is no point in building the binaries twice, we just want to create the image so we only build on the dockerfile, that has the required dependencies for that

This fixes https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-kindnet-image/1978734462321561600