### PR TITLE
ensure buildx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ update:
 	gofmt -s -w ./
 	hack/update-license-header.sh
 
+.PHONY: ensure-buildx
+ensure-buildx:
+	./hack/init-buildx.sh
+
 # get image name from directory we're building
 IMAGE_NAME=kindnet
 # docker image registry, default to upstream
@@ -40,13 +44,13 @@ PROGRESS?=auto
 # required to enable buildx
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
-image-build:
+image-build: ensure-buildx
 	docker buildx build . \
 		--progress="${PROGRESS}" \
 		--platform="${PLATFORMS}" \
 		--tag="${IMAGE}" --load
 
-image-push:
+image-push: ensure-buildx
 	docker buildx build . \
 		--progress="${PROGRESS}" \
 		--platform="${PLATFORMS}" \

--- a/hack/init-buildx.sh
+++ b/hack/init-buildx.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit -o nounset -o pipefail
+
+# We can skip setup if the current builder already has multi-arch
+# AND if it isn't the docker driver, which doesn't work
+current_builder="$(docker buildx inspect)"
+# linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7, linux/arm/v6
+if ! grep -q "^Driver: docker$" <<<"${current_builder}" && \
+     grep -q "linux/amd64" <<<"${current_builder}" && \
+     grep -q "linux/arm64" <<<"${current_builder}"; then
+  exit 0
+fi
+
+# Ensure qemu is in binfmt_misc
+# Docker desktop already has these in versions recent enough to have buildx
+# We only need to do this setup on linux hosts
+if [ "$(uname)" == 'Linux' ]; then
+  # NOTE: this is pinned to a digest for a reason!
+  docker run --rm --privileged tonistiigi/binfmt:qemu-v7.0.0-28@sha256:66e11bea77a5ea9d6f0fe79b57cd2b189b5d15b93a2bdb925be22949232e4e55 --install all
+fi
+
+# Ensure we use a builder that can leverage it (the default on linux will not)
+docker buildx rm knp-builder || true
+docker buildx create --use --name=knp-builder


### PR DESCRIPTION
Job now fails with https://prow.k8s.io/log?job=post-kindnet-image&id=1978752805577428992

```
tus: Downloaded newer image for gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest
gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest
docker buildx build . \
	--progress="auto" \
	--platform="linux/amd64,linux/arm64" \
	--tag="gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079" --push
ERROR: Multi-platform build is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again.
Learn more at https://docs.docker.com/go/build-multi-platform/
make: *** [Makefile:50: image-push] Error 1
ERROR
ERROR: build step 0 "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud" failed: step exited with non-zero status: 2
--------------------------------------------------------------------------------
2025/10/16 09:22:37 Failed to run some build jobs: [error running [gcloud builds submit --verbosity info --config /home/prow/go/src/github.com/kubernetes-sigs/kindnet/cloudbuild.yaml --substitutions _PULL_BASE_SHA=ce852b3ebd46cbc1803a533f036d7903a9bb133b,_GIT_TAG=v20251016-ce852b3 --project k8s-staging-networking --gcs-log-dir gs://k8s-staging-networking-gcb/logs --gcs-source-staging-dir gs://k8s-staging-networking-gcb/source gs://k8s-staging-networking-gcb/source/74952561-fd48-46b9-94ab-212df32e84db.tgz --polling-interval 10]: exit status 1]
{"component":"entrypoint","error":"wrapped process failed: exit status 1","file":"sigs.k8s.io/prow/pkg/entrypoint/run.go:84","func":"sigs.k8s.io/prow/pkg/entrypoint.Options.internalRun","level":"error","msg":"Error executing test process","severity":"error","time":"2025-10-16T09:22:37Z"}
```