### PR TITLE
dependabot: Add labels and correct grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,19 +9,30 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      k8s:
+        patterns:
+          - "*k8s.io*"
+      aws:
+        patterns:
+          - "github.com/aws/*"
+    labels:
+      - "area/dependency"
+      - "ok-to-test"
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
+    labels:
+      - "area/dependency"
+      - "ok-to-test"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
-    groups:
-      k8s:
-        patterns:
-        - "k8s.io/*"
-        - "sigs.k8s.io/*"
+    labels:
+      - "area/dependency"
+      - "ok-to-test"


### PR DESCRIPTION
This configures dependabot updates to automatically add ok-to-test labels and corrects the location for grouping Go dependency updates. In addition to the k8s.io grouping it also adds an AWS grouping since those are also almost always intended to be taken as a set.