### PR TITLE
dependabot: Add grouping for golang.org/x packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,9 @@ updates:
       aws:
         patterns:
           - "github.com/aws/*"
+      golangx:
+        patterns:
+          - "golang.org/x/*"
     labels:
       - "area/dependency"
       - "ok-to-test"


### PR DESCRIPTION
There are several independent packages under golang.org/x, but the majority of the time they are released together and we want to take those updates together. To reduce the number of PRs and the time to review and test them, this adds a grouping configuration so only one update for all packages will be proposed.