### PR TITLE
Honor stderrthreshold when logtostderr is enabled

### DIFF
--- a/cmd/kindnetd/main.go
+++ b/cmd/kindnetd/main.go
@@ -128,6 +128,8 @@ func main() {
 	// enable logging
 	klog.InitFlags(nil)
 	_ = flag.Set("logtostderr", "true")
+	_ = flag.Set("legacy_stderr_threshold_behavior", "false")
+	_ = flag.Set("stderrthreshold", "INFO")
 	flag.Parse()
 	flag.VisitAll(func(flag *flag.Flag) {
 		klog.Infof("FLAG: --%s=%q", flag.Name, flag.Value)


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

When `logtostderr` is set to `true`, klog's `stderrthreshold` flag is ignored due to a legacy default behavior in klog v2. This means all log levels (including INFO and DEBUG) are written to stderr, regardless of the `stderrthreshold` setting.

This PR sets `legacy_stderr_threshold_behavior` to `false` in `cmd/kindnetd/main.go` to opt into the corrected behavior introduced in [klog PR #432](https://github.com/kubernetes/klog/pull/432), where `stderrthreshold` is respected even when `logtostderr=true`.

## Which issue(s) this PR fixes

Fixes a logging behavior issue where `stderrthreshold` was silently ignored.

## Special notes for your reviewer

The `legacy_stderr_threshold_behavior` flag was introduced in klog v2.140.0, which is already the version used by this project. Setting it to `false` opts into the corrected behavior.

Reference: https://github.com/kubernetes/klog/pull/432

> This contribution is AI-assisted.