### PR TITLE
Only run CI on activity to main

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -4,11 +4,13 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main 
+      - main
     paths: 
       - 'site/**'
       - '.github/workflows/deploy-github-pages.yml'
   pull_request:
+    branches:
+      - main
     paths:
       - 'site/**'
       - '.github/workflows/deploy-github-pages.yml'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,12 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
This limits the GitHub Action workflows to only trigger on pull requests or pushes to the main branch. This reduces unnecessary CI time for things like in-development pushes to dev branches.