### PR TITLE
ci: declare contents: read on e2e and test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,6 +18,9 @@ env:
   KIND_VERSION: "v0.30.0"
   KIND_CLUSTER_NAME: "kindnet"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` for the two CI workflows still inheriting org defaults:

- `e2e.yml` — builds the kindnet image, spins up a kind cluster, and runs ginkgo conformance tests across the ipv4/ipv6/dual × ptp/ipsec matrix. Artifacts upload via `actions/upload-artifact` (run-scoped, no API writes).
- `test.yaml` — runs `sudo make test` and `make verify`.

Neither workflow touches the GitHub API beyond checkout, so `contents: read` covers both. YAML validated locally.