### PR TITLE
add multicast support using an user-space proxy forwarding agent

### DIFF
--- a/.github/workflows/e2e-bats.yml
+++ b/.github/workflows/e2e-bats.yml
@@ -1,0 +1,54 @@
+name: Bats E2E
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'main'
+  pull_request:
+    branches:
+      - 'master'
+      - 'main'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-bats:
+    name: BATS E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+    - name: Set up Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      with:
+        go-version-file: .go-version
+
+    - name: Install KIND
+      run: |
+        curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.30.0/kind-linux-amd64
+        sudo chmod +x ./kind
+        sudo mv ./kind /usr/local/bin/kind
+
+    - name: Install kubectl
+      run: |
+        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+        sudo chmod +x ./kubectl
+        sudo mv ./kubectl /usr/local/bin/kubectl
+
+    - name: Install BATS
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y bats
+
+    - name: Enable ipv4 and ipv6 forwarding
+      run: |
+        sudo sysctl -w net.ipv6.conf.all.forwarding=1
+        sudo sysctl -w net.ipv4.ip_forward=1
+
+    - name: Run BATS E2E tests
+      run: |
+        bats tests/

--- a/cmd/kindnetd/main.go
+++ b/cmd/kindnetd/main.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/kindnet/pkg/dnscache"
 	"sigs.k8s.io/kindnet/pkg/fastpath"
 	"sigs.k8s.io/kindnet/pkg/masq"
+	"sigs.k8s.io/kindnet/pkg/multicast"
 	kindnetnat64 "sigs.k8s.io/kindnet/pkg/nat64"
 	"sigs.k8s.io/kindnet/pkg/nflog"
 	kindnetnode "sigs.k8s.io/kindnet/pkg/node"
@@ -99,6 +100,7 @@ var (
 	nflogLevel                 int
 	ipsecOverlay               bool
 	nameServers                string
+	enableMulticast            bool
 )
 
 func init() {
@@ -117,6 +119,7 @@ func init() {
 
 	flag.IntVar(&nflogLevel, "nflog-level", 9, "The log level at which the TCP and UDP packets are logged to stdout (default 9)")
 	flag.BoolVar(&ipsecOverlay, "ipsec-overlay", false, "use IPSec to tunnel traffic between nodes (default false)")
+	flag.BoolVar(&enableMulticast, "multicast", false, "If set, enable multicast support (default false)")
 
 	flag.Usage = func() {
 		fmt.Fprint(os.Stderr, "Usage: kindnet [options]\n\n")
@@ -339,6 +342,22 @@ func main() {
 	} else {
 		klog.Info("Skipping nflog agent, cleaning old rules")
 		nflog.CleanRules()
+	}
+
+	if enableMulticast {
+		klog.Info("Multicast support enabled")
+		multicastAgent, err := multicast.NewMulticastAgent()
+		if err != nil {
+			klog.Fatalf("error creating multicast agent: %v", err)
+		}
+		go func() {
+			if err := multicastAgent.Run(ctx); err != nil {
+				klog.Infof("error running multicastAgent: %v", err)
+			}
+		}()
+	} else {
+		klog.Info("Skipping multicast agent, cleaning old rules")
+		multicast.CleanRules()
 	}
 
 	// network policies

--- a/pkg/multicast/agent.go
+++ b/pkg/multicast/agent.go
@@ -22,10 +22,12 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
+	"unsafe"
 
 	"github.com/vishvananda/netlink"
 	"golang.org/x/net/ipv4"
@@ -43,26 +45,338 @@ type MulticastAgent struct {
 	// upstreamIfIndex is the interface index of the host's default gateway interface
 	upstreamIfIndex int
 	upstreamName    string
+
+	// Low-level multicast routing sockets
+	mcastSocket4 int
+	mcastSocket6 int
+
+	// VIF tracking
+	vifMap  map[string]uint16
+	vifUsed [32]bool
 }
 
 func NewMulticastAgent() (*MulticastAgent, error) {
 	return &MulticastAgent{
 		groupToIfaces: make(map[string]map[string]bool),
 		activeJoins:   make(map[string]interface{}),
+		vifMap:        make(map[string]uint16),
 	}, nil
+}
+
+func (ma *MulticastAgent) initSockets() error {
+	// Initialize sysctls first
+	_ = os.WriteFile("/proc/sys/net/ipv4/conf/all/rp_filter", []byte("0"), 0644)
+	_ = os.WriteFile("/proc/sys/net/ipv4/conf/default/rp_filter", []byte("0"), 0644)
+
+	// IPv4 Socket
+	fd4, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_RAW, syscall.IPPROTO_IGMP)
+	if err != nil {
+		return fmt.Errorf("failed to open raw IPv4 IGMP socket: %w", err)
+	}
+	ma.mcastSocket4 = fd4
+
+	// Enable IPv4 multicast routing
+	if err := unix.SetsockoptInt(fd4, unix.IPPROTO_IP, MRT_INIT, 1); err != nil {
+		_ = syscall.Close(fd4)
+		ma.mcastSocket4 = 0
+		return fmt.Errorf("failed to initialize IPv4 multicast routing (MRT_INIT): %w", err)
+	}
+
+	// IPv6 Socket
+	fd6, err := syscall.Socket(syscall.AF_INET6, syscall.SOCK_RAW, syscall.IPPROTO_ICMPV6)
+	if err != nil {
+		klog.Warningf("failed to open raw IPv6 ICMPv6 socket: %v", err)
+	} else {
+		ma.mcastSocket6 = fd6
+		// Enable IPv6 multicast routing
+		if err := unix.SetsockoptInt(fd6, unix.IPPROTO_IPV6, MRT6_INIT, 1); err != nil {
+			_ = syscall.Close(fd6)
+			ma.mcastSocket6 = 0
+			klog.Warningf("failed to initialize IPv6 multicast routing (MRT6_INIT): %v", err)
+		}
+	}
+	return nil
+}
+
+func (ma *MulticastAgent) cleanupSockets() {
+	ma.Lock()
+	defer ma.Unlock()
+
+	if ma.mcastSocket4 != 0 {
+		_ = unix.SetsockoptInt(ma.mcastSocket4, unix.IPPROTO_IP, MRT_DONE, 0)
+		_ = syscall.Close(ma.mcastSocket4)
+		ma.mcastSocket4 = 0
+	}
+	if ma.mcastSocket6 != 0 {
+		_ = unix.SetsockoptInt(ma.mcastSocket6, unix.IPPROTO_IPV6, MRT6_DONE, 0)
+		_ = syscall.Close(ma.mcastSocket6)
+		ma.mcastSocket6 = 0
+	}
+}
+
+func (ma *MulticastAgent) registerInterface(ifaceName string, ifIndex int) (uint16, error) {
+	if idx, exists := ma.vifMap[ifaceName]; exists {
+		return idx, nil
+	}
+
+	var vifIdx int = -1
+	if ifaceName == ma.upstreamName {
+		vifIdx = 0
+	} else {
+		for i := 1; i < 32; i++ {
+			if !ma.vifUsed[i] {
+				vifIdx = i
+				break
+			}
+		}
+	}
+
+	if vifIdx == -1 {
+		return 0, fmt.Errorf("no available VIF index for interface %s", ifaceName)
+	}
+
+	// Configure sysctl to disable reverse path filtering on the new interface
+	_ = os.WriteFile(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/rp_filter", ifaceName), []byte("0"), 0644)
+
+	// Register with IPv4
+	if ma.mcastSocket4 != 0 {
+		vif := vifctl{
+			vifc_vifi:        uint16(vifIdx),
+			vifc_flags:       VIFF_USE_IFINDEX,
+			vifc_threshold:   1,
+			vifc_rate_limit:  0,
+			vifc_lcl_ifindex: int32(ifIndex),
+		}
+		ptr := unsafe.Pointer(&vif)
+		size := unsafe.Sizeof(vif)
+		buf := unsafe.Slice((*byte)(ptr), size)
+		err := unix.SetsockoptString(ma.mcastSocket4, unix.IPPROTO_IP, MRT_ADD_VIF, string(buf))
+		if err != nil {
+			klog.Errorf("failed to add IPv4 VIF for %s (vifi %d): %v", ifaceName, vifIdx, err)
+		} else {
+			klog.Infof("Successfully added IPv4 VIF for %s (vifi %d)", ifaceName, vifIdx)
+		}
+	}
+
+	// Register with IPv6
+	if ma.mcastSocket6 != 0 {
+		mif := mif6ctl{
+			mif6c_mifi:      uint16(vifIdx),
+			mif6c_flags:     0,
+			vifc_threshold:  1,
+			mif6c_pifi:      uint16(ifIndex),
+			vifc_rate_limit: 0,
+		}
+		ptr := unsafe.Pointer(&mif)
+		size := unsafe.Sizeof(mif)
+		buf := unsafe.Slice((*byte)(ptr), size)
+		err := unix.SetsockoptString(ma.mcastSocket6, unix.IPPROTO_IPV6, MRT6_ADD_MIF, string(buf))
+		if err != nil {
+			klog.Errorf("failed to add IPv6 MIF for %s (mifi %d): %v", ifaceName, vifIdx, err)
+		} else {
+			klog.Infof("Successfully added IPv6 MIF for %s (mifi %d)", ifaceName, vifIdx)
+		}
+	}
+
+	ma.vifMap[ifaceName] = uint16(vifIdx)
+	ma.vifUsed[vifIdx] = true
+	return uint16(vifIdx), nil
+}
+
+func (ma *MulticastAgent) unregisterInterface(ifaceName string) {
+	vifIdx, exists := ma.vifMap[ifaceName]
+	if !exists {
+		return
+	}
+
+	// Unregister with IPv4
+	if ma.mcastSocket4 != 0 {
+		vif := vifctl{
+			vifc_vifi: vifIdx,
+		}
+		ptr := unsafe.Pointer(&vif)
+		size := unsafe.Sizeof(vif)
+		buf := unsafe.Slice((*byte)(ptr), size)
+		_ = unix.SetsockoptString(ma.mcastSocket4, unix.IPPROTO_IP, MRT_DEL_VIF, string(buf))
+	}
+
+	// Unregister with IPv6
+	if ma.mcastSocket6 != 0 {
+		mif := mif6ctl{
+			mif6c_mifi: vifIdx,
+		}
+		ptr := unsafe.Pointer(&mif)
+		size := unsafe.Sizeof(mif)
+		buf := unsafe.Slice((*byte)(ptr), size)
+		_ = unix.SetsockoptString(ma.mcastSocket6, unix.IPPROTO_IPV6, MRT6_DEL_MIF, string(buf))
+	}
+
+	delete(ma.vifMap, ifaceName)
+	ma.vifUsed[vifIdx] = false
+	klog.Infof("Successfully removed VIF/MIF for %s (index %d)", ifaceName, vifIdx)
+}
+
+func (ma *MulticastAgent) addMfc(src, grp net.IP, parentVif uint16, outgoingVifs []uint16) error {
+	if ma.mcastSocket4 == 0 {
+		return fmt.Errorf("IPv4 multicast socket not initialized")
+	}
+
+	var mfc mfcctl
+	copy(mfc.mfcc_origin[:], src.To4())
+	copy(mfc.mfcc_mcastgrp[:], grp.To4())
+	mfc.mfcc_parent = parentVif
+
+	for i := range mfc.mfcc_ttls {
+		mfc.mfcc_ttls[i] = 0
+	}
+	for _, vif := range outgoingVifs {
+		if vif < 32 {
+			mfc.mfcc_ttls[vif] = 1
+		}
+	}
+
+	ptr := unsafe.Pointer(&mfc)
+	size := unsafe.Sizeof(mfc)
+	buf := unsafe.Slice((*byte)(ptr), size)
+
+	err := unix.SetsockoptString(ma.mcastSocket4, unix.IPPROTO_IP, MRT_ADD_MFC, string(buf))
+	if err != nil {
+		return fmt.Errorf("failed to add IPv4 MFC entry: %w", err)
+	}
+	klog.V(2).Infof("Successfully added IPv4 MFC entry for (%s, %s) parent VIF %d", src, grp, parentVif)
+	return nil
+}
+
+func (ma *MulticastAgent) addMfc6(src, grp net.IP, parentMif uint16, outgoingMifs []uint16) error {
+	if ma.mcastSocket6 == 0 {
+		return fmt.Errorf("IPv6 multicast socket not initialized")
+	}
+
+	var mfc mf6cctl
+	mfc.mf6cc_origin.sin6_family = unix.AF_INET6
+	copy(mfc.mf6cc_origin.sin6_addr[:], src.To16())
+	mfc.mf6cc_mcastgrp.sin6_family = unix.AF_INET6
+	copy(mfc.mf6cc_mcastgrp.sin6_addr[:], grp.To16())
+	mfc.mf6cc_parent = parentMif
+
+	for _, mif := range outgoingMifs {
+		if mif < 256 {
+			word := mif / 32
+			bit := mif % 32
+			mfc.mf6cc_ifset[word] |= (1 << bit)
+		}
+	}
+
+	ptr := unsafe.Pointer(&mfc)
+	size := unsafe.Sizeof(mfc)
+	buf := unsafe.Slice((*byte)(ptr), size)
+
+	err := unix.SetsockoptString(ma.mcastSocket6, unix.IPPROTO_IPV6, MRT6_ADD_MFC, string(buf))
+	if err != nil {
+		return fmt.Errorf("failed to add IPv6 MFC entry: %w", err)
+	}
+	klog.V(2).Infof("Successfully added IPv6 MFC entry for (%s, %s) parent MIF %d", src, grp, parentMif)
+	return nil
+}
+
+func (ma *MulticastAgent) deleteMfc(src, grp net.IP) error {
+	if ma.mcastSocket4 == 0 {
+		return nil
+	}
+	var mfc mfcctl
+	copy(mfc.mfcc_origin[:], src.To4())
+	copy(mfc.mfcc_mcastgrp[:], grp.To4())
+
+	ptr := unsafe.Pointer(&mfc)
+	size := unsafe.Sizeof(mfc)
+	buf := unsafe.Slice((*byte)(ptr), size)
+
+	_ = unix.SetsockoptString(ma.mcastSocket4, unix.IPPROTO_IP, MRT_DEL_MFC, string(buf))
+	return nil
+}
+
+func (ma *MulticastAgent) deleteMfc6(src, grp net.IP) error {
+	if ma.mcastSocket6 == 0 {
+		return nil
+	}
+	var mfc mf6cctl
+	mfc.mf6cc_origin.sin6_family = unix.AF_INET6
+	copy(mfc.mf6cc_origin.sin6_addr[:], src.To16())
+	mfc.mf6cc_mcastgrp.sin6_family = unix.AF_INET6
+	copy(mfc.mf6cc_mcastgrp.sin6_addr[:], grp.To16())
+
+	ptr := unsafe.Pointer(&mfc)
+	size := unsafe.Sizeof(mfc)
+	buf := unsafe.Slice((*byte)(ptr), size)
+
+	_ = unix.SetsockoptString(ma.mcastSocket6, unix.IPPROTO_IPV6, MRT6_DEL_MFC, string(buf))
+	return nil
+}
+
+func (ma *MulticastAgent) handleNoCacheIPv4(src, grp net.IP, parentVif uint16) {
+	groupStr := grp.String()
+	ma.RLock()
+	ifaces, exists := ma.groupToIfaces[groupStr]
+	if !exists || len(ifaces) == 0 {
+		ma.RUnlock()
+		return
+	}
+
+	outgoingVifs := make([]uint16, 0, len(ifaces))
+	for ifaceName := range ifaces {
+		if vif, registered := ma.vifMap[ifaceName]; registered {
+			outgoingVifs = append(outgoingVifs, vif)
+		}
+	}
+	ma.RUnlock()
+
+	if len(outgoingVifs) > 0 {
+		_ = ma.addMfc(src, grp, parentVif, outgoingVifs)
+	}
+}
+
+func (ma *MulticastAgent) handleNoCacheIPv6(src, grp net.IP, parentMif uint16) {
+	groupStr := grp.String()
+	ma.RLock()
+	ifaces, exists := ma.groupToIfaces[groupStr]
+	if !exists || len(ifaces) == 0 {
+		ma.RUnlock()
+		return
+	}
+
+	outgoingMifs := make([]uint16, 0, len(ifaces))
+	for ifaceName := range ifaces {
+		if mif, registered := ma.vifMap[ifaceName]; registered {
+			outgoingMifs = append(outgoingMifs, mif)
+		}
+	}
+	ma.RUnlock()
+
+	if len(outgoingMifs) > 0 {
+		_ = ma.addMfc6(src, grp, parentMif, outgoingMifs)
+	}
 }
 
 func (ma *MulticastAgent) Run(ctx context.Context) error {
 	klog.Info("Starting Multicast Agent")
+
+	// Initialize multicast routing sockets
+	if err := ma.initSockets(); err != nil {
+		return fmt.Errorf("failed to initialize multicast routing sockets: %w", err)
+	}
+	defer ma.cleanupSockets()
 
 	// Find default upstream interface
 	upstream, err := getUpstreamInterface()
 	if err != nil {
 		klog.Warningf("Could not find upstream interface: %v. Retrying in background...", err)
 	} else {
+		ma.Lock()
 		ma.upstreamIfIndex = upstream.Index
 		ma.upstreamName = upstream.Name
+		ma.Unlock()
 		klog.Infof("Using upstream interface: %s (index %d)", upstream.Name, upstream.Index)
+		_, _ = ma.registerInterface(upstream.Name, upstream.Index)
 	}
 
 	// Set up netlink subscriber to monitor interface changes
@@ -89,15 +403,87 @@ func (ma *MulticastAgent) Run(ctx context.Context) error {
 				ma.Lock()
 				if ma.upstreamIfIndex != up.Index {
 					klog.Infof("Upstream interface changed from %s to %s", ma.upstreamName, up.Name)
+					ma.unregisterInterface(ma.upstreamName)
 					ma.upstreamIfIndex = up.Index
 					ma.upstreamName = up.Name
+					_, _ = ma.registerInterface(up.Name, up.Index)
 				}
 				ma.Unlock()
 			}
 		}
 	}()
 
-	// Open the raw packet socket for capturing all packet traffic
+	// Read IPv4 upcalls
+	go func() {
+		if ma.mcastSocket4 == 0 {
+			return
+		}
+		buf := make([]byte, 1024)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			n, err := syscall.Read(ma.mcastSocket4, buf)
+			if err != nil {
+				if errors.Is(err, syscall.EAGAIN) || errors.Is(err, syscall.EWOULDBLOCK) {
+					time.Sleep(10 * time.Millisecond)
+					continue
+				}
+				klog.Errorf("Error reading from IPv4 multicast socket: %v", err)
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+			if n >= 20 {
+				var msg igmpmsg
+				ptr := unsafe.Pointer(&buf[0])
+				msg = *(*igmpmsg)(ptr)
+				if msg.im_msgtype == 1 { // IGMPMSG_NOCACHE
+					src := net.IP(msg.im_src[:])
+					grp := net.IP(msg.im_dst[:])
+					ma.handleNoCacheIPv4(src, grp, uint16(msg.im_vif))
+				}
+			}
+		}
+	}()
+
+	// Read IPv6 upcalls
+	go func() {
+		if ma.mcastSocket6 == 0 {
+			return
+		}
+		buf := make([]byte, 1024)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			n, err := syscall.Read(ma.mcastSocket6, buf)
+			if err != nil {
+				if errors.Is(err, syscall.EAGAIN) || errors.Is(err, syscall.EWOULDBLOCK) {
+					time.Sleep(10 * time.Millisecond)
+					continue
+				}
+				klog.Errorf("Error reading from IPv6 multicast socket: %v", err)
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+			if n >= 40 {
+				var msg mrt6msg
+				ptr := unsafe.Pointer(&buf[0])
+				msg = *(*mrt6msg)(ptr)
+				if msg.im6_msgtype == 1 { // MRT6MSG_NOCACHE
+					src := net.IP(msg.im6_src[:])
+					grp := net.IP(msg.im6_dst[:])
+					ma.handleNoCacheIPv6(src, grp, msg.im6_mif)
+				}
+			}
+		}
+	}()
+
+	// Open the raw packet socket for capturing Pod IGMP/MLD reports
 	fd, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_RAW, int(htons(unix.ETH_P_ALL)))
 	if err != nil {
 		return fmt.Errorf("failed to open raw packet socket: %w", err)
@@ -174,134 +560,6 @@ func (ma *MulticastAgent) handlePacket(packet []byte, sll *syscall.SockaddrLinkl
 				ma.parseAndHandleMLD(payload, iface.Name)
 			}
 		}
-		return
-	}
-
-	// Process Multicast Data from Upstream Interface
-	ma.RLock()
-	isUpstream := sll.Ifindex == ma.upstreamIfIndex
-	ma.RUnlock()
-
-	if isUpstream {
-		var dstIP net.IP
-		var groupStr string
-
-		if etherType == unix.ETH_P_IP && len(ipPayload) >= 20 {
-			dstIP = net.IP(ipPayload[16:20])
-			if dstIP.IsMulticast() && !isLinkLocalMulticastIPv4(dstIP) {
-				groupStr = dstIP.String()
-			}
-		} else if etherType == unix.ETH_P_IPV6 && len(ipPayload) >= 40 {
-			dstIP = net.IP(ipPayload[24:40])
-			if dstIP.IsMulticast() && !isLinkLocalMulticastIPv6(dstIP) {
-				groupStr = dstIP.String()
-			}
-		}
-
-		if groupStr != "" {
-			ma.RLock()
-			ifaces, exists := ma.groupToIfaces[groupStr]
-			if exists && len(ifaces) > 0 {
-				// Forward this packet to all interested pod interfaces
-				for ifaceName := range ifaces {
-					targetIface, err := net.InterfaceByName(ifaceName)
-					if err == nil {
-						ma.forwardRawPacket(packet, targetIface.Index, etherType)
-					}
-				}
-			}
-			ma.RUnlock()
-		}
-	}
-}
-
-func (ma *MulticastAgent) parseAndHandleIGMP(igmpData []byte, ifaceName string) {
-	if len(igmpData) < 8 {
-		return
-	}
-	igmpType := igmpData[0]
-	groupIP := net.IP(igmpData[4:8])
-
-	switch igmpType {
-	case 0x16: // IGMPv2 Membership Report
-		ma.joinGroup(groupIP, ifaceName)
-	case 0x17: // IGMPv2 Leave Group
-		ma.leaveGroup(groupIP, ifaceName)
-	case 0x22: // IGMPv3 Membership Report
-		// Parse group records
-		if len(igmpData) >= 8 {
-			numRecords := binary.BigEndian.Uint16(igmpData[6:8])
-			offset := 8
-			for i := 0; i < int(numRecords); i++ {
-				if len(igmpData) < offset+8 {
-					break
-				}
-				recordType := igmpData[offset]
-				numSources := binary.BigEndian.Uint16(igmpData[offset+2 : offset+4])
-				mcastAddr := net.IP(igmpData[offset+4 : offset+8])
-
-				// Record types: 1 = MODE_IS_INCLUDE, 2 = MODE_IS_EXCLUDE, 3 = CHANGE_TO_INCLUDE_MODE, 4 = CHANGE_TO_EXCLUDE_MODE, 5 = ALLOW_NEW_SOURCES, 6 = BLOCK_OLD_SOURCES
-				switch recordType {
-				case 1, 2, 3, 4, 5:
-					if recordType == 1 && numSources == 0 {
-						// INCLUDE with 0 sources is equivalent to leaving the group
-						ma.leaveGroup(mcastAddr, ifaceName)
-					} else {
-						ma.joinGroup(mcastAddr, ifaceName)
-					}
-				case 6:
-					ma.leaveGroup(mcastAddr, ifaceName)
-				}
-				offset += 8 + int(numSources)*4
-			}
-		}
-	}
-}
-
-func (ma *MulticastAgent) parseAndHandleMLD(icmpv6Data []byte, ifaceName string) {
-	if len(icmpv6Data) < 8 {
-		return
-	}
-	icmpType := icmpv6Data[0]
-
-	// MLDv1: 131 = Multicast Listener Report, 132 = Multicast Listener Done
-	// MLDv2: 143 = Multicast Listener Report v2
-	switch icmpType {
-	case 131:
-		if len(icmpv6Data) >= 24 {
-			groupIP := net.IP(icmpv6Data[8:24])
-			ma.joinGroup(groupIP, ifaceName)
-		}
-	case 132:
-		if len(icmpv6Data) >= 24 {
-			groupIP := net.IP(icmpv6Data[8:24])
-			ma.leaveGroup(groupIP, ifaceName)
-		}
-	case 143:
-		if len(icmpv6Data) >= 6 {
-			numRecords := binary.BigEndian.Uint16(icmpv6Data[6:8])
-			offset := 8
-			for i := 0; i < int(numRecords); i++ {
-				if len(icmpv6Data) < offset+20 {
-					break
-				}
-				recordType := icmpv6Data[offset]
-				numSources := binary.BigEndian.Uint16(icmpv6Data[offset+2 : offset+4])
-				mcastAddr := net.IP(icmpv6Data[offset+4 : offset+20])
-
-				switch recordType {
-				case 1, 2, 3, 4, 5:
-					if recordType == 1 && numSources == 0 {
-						ma.leaveGroup(mcastAddr, ifaceName)
-					} else {
-						ma.joinGroup(mcastAddr, ifaceName)
-					}
-				case 6:
-					ma.leaveGroup(mcastAddr, ifaceName)
-				}
-				offset += 20 + int(numSources)*16
-			}
-		}
 	}
 }
 
@@ -312,23 +570,37 @@ func (ma *MulticastAgent) joinGroup(groupIP net.IP, ifaceName string) {
 	ma.Lock()
 	defer ma.Unlock()
 
+	ifi, err := net.InterfaceByName(ifaceName)
+	if err != nil {
+		klog.Warningf("Warning: interface %s not found on system: %v", ifaceName, err)
+	} else {
+		_, err = ma.registerInterface(ifaceName, ifi.Index)
+		if err != nil {
+			klog.Errorf("Error registering interface %s: %v", ifaceName, err)
+		}
+	}
+
 	if _, exists := ma.groupToIfaces[groupStr]; !exists {
 		ma.groupToIfaces[groupStr] = make(map[string]bool)
 	}
 	ma.groupToIfaces[groupStr][ifaceName] = true
 
-	// Join group on upstream interface if not already done
+	if ma.upstreamIfIndex != 0 && ma.upstreamName != "" {
+		_, _ = ma.registerInterface(ma.upstreamName, ma.upstreamIfIndex)
+	}
+
+	// Join group on upstream interface
 	if _, active := ma.activeJoins[groupStr]; !active && ma.upstreamIfIndex != 0 {
-		ifi, err := net.InterfaceByIndex(ma.upstreamIfIndex)
+		ifiUp, err := net.InterfaceByIndex(ma.upstreamIfIndex)
 		if err == nil {
 			if groupIP.To4() != nil {
 				c, err := net.ListenPacket("udp4", "0.0.0.0:0")
 				if err == nil {
 					p := ipv4.NewPacketConn(c)
-					err = p.JoinGroup(ifi, &net.UDPAddr{IP: groupIP})
+					err = p.JoinGroup(ifiUp, &net.UDPAddr{IP: groupIP})
 					if err == nil {
 						ma.activeJoins[groupStr] = c
-						klog.Infof("Successfully joined IPv4 group %s on upstream %s", groupStr, ifi.Name)
+						klog.Infof("Successfully joined IPv4 group %s on upstream %s", groupStr, ifiUp.Name)
 					} else {
 						_ = c.Close()
 						klog.Errorf("Error joining IPv4 group %s on upstream: %v", groupStr, err)
@@ -338,10 +610,10 @@ func (ma *MulticastAgent) joinGroup(groupIP net.IP, ifaceName string) {
 				c, err := net.ListenPacket("udp6", "[::]:0")
 				if err == nil {
 					p := ipv6.NewPacketConn(c)
-					err = p.JoinGroup(ifi, &net.UDPAddr{IP: groupIP})
+					err = p.JoinGroup(ifiUp, &net.UDPAddr{IP: groupIP})
 					if err == nil {
 						ma.activeJoins[groupStr] = c
-						klog.Infof("Successfully joined IPv6 group %s on upstream %s", groupStr, ifi.Name)
+						klog.Infof("Successfully joined IPv6 group %s on upstream %s", groupStr, ifiUp.Name)
 					} else {
 						_ = c.Close()
 						klog.Errorf("Error joining IPv6 group %s on upstream: %v", groupStr, err)
@@ -363,7 +635,6 @@ func (ma *MulticastAgent) leaveGroup(groupIP net.IP, ifaceName string) {
 		delete(ifaces, ifaceName)
 		if len(ifaces) == 0 {
 			delete(ma.groupToIfaces, groupStr)
-			// Leave group on upstream interface
 			if c, active := ma.activeJoins[groupStr]; active {
 				if conn, ok := c.(net.PacketConn); ok {
 					_ = conn.Close()
@@ -373,36 +644,21 @@ func (ma *MulticastAgent) leaveGroup(groupIP net.IP, ifaceName string) {
 			}
 		}
 	}
-}
 
-func (ma *MulticastAgent) forwardRawPacket(packet []byte, targetIfIndex int, etherType uint16) {
-	fd, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_RAW, int(htons(etherType)))
-	if err != nil {
-		return
+	inUse := false
+	for _, ifaces := range ma.groupToIfaces {
+		if ifaces[ifaceName] {
+			inUse = true
+			break
+		}
 	}
-	defer func() {
-		_ = syscall.Close(fd)
-	}()
-
-	broadcastMAC := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
-	addr := &syscall.SockaddrLinklayer{
-		Protocol: htons(etherType),
-		Ifindex:  targetIfIndex,
-		Hatype:   syscall.ARPHRD_ETHER,
-		Pkttype:  syscall.PACKET_OUTGOING,
-		Halen:    6,
+	if !inUse {
+		ma.unregisterInterface(ifaceName)
 	}
-	copy(addr.Addr[:6], broadcastMAC)
-
-	// Rewrite Ethernet header destination to broadcast
-	copy(packet[0:6], broadcastMAC)
-
-	_ = syscall.Sendto(fd, packet, 0, addr)
 }
 
 func CleanRules() {
-	// Independent agent doesn't install firewall rules in user space mode,
-	// so cleanup is a no-op.
+	// Independent agent doesn't install firewall rules, so cleanup is a no-op.
 }
 
 func getUpstreamInterface() (*net.Interface, error) {
@@ -423,12 +679,4 @@ func getUpstreamInterface() (*net.Interface, error) {
 
 func htons(i uint16) uint16 {
 	return (i << 8) | (i >> 8)
-}
-
-func isLinkLocalMulticastIPv4(ip net.IP) bool {
-	return ip[0] == 224 && ip[1] == 0 && ip[2] == 0
-}
-
-func isLinkLocalMulticastIPv6(ip net.IP) bool {
-	return ip[0] == 0xff && (ip[1]&0x0f) <= 0x02
 }

--- a/pkg/multicast/agent.go
+++ b/pkg/multicast/agent.go
@@ -1,0 +1,434 @@
+/*
+Copyright YEAR The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multicast
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+	"golang.org/x/sys/unix"
+	"k8s.io/klog/v2"
+)
+
+type MulticastAgent struct {
+	sync.RWMutex
+	// groupToIfaces tracks multicast groups to pod interface names
+	groupToIfaces map[string]map[string]bool
+	// activeJoins tracks active UDP listeners that keep the upstream multicast membership alive
+	activeJoins map[string]interface{}
+	// upstreamIfIndex is the interface index of the host's default gateway interface
+	upstreamIfIndex int
+	upstreamName    string
+}
+
+func NewMulticastAgent() (*MulticastAgent, error) {
+	return &MulticastAgent{
+		groupToIfaces: make(map[string]map[string]bool),
+		activeJoins:   make(map[string]interface{}),
+	}, nil
+}
+
+func (ma *MulticastAgent) Run(ctx context.Context) error {
+	klog.Info("Starting Multicast Agent")
+
+	// Find default upstream interface
+	upstream, err := getUpstreamInterface()
+	if err != nil {
+		klog.Warningf("Could not find upstream interface: %v. Retrying in background...", err)
+	} else {
+		ma.upstreamIfIndex = upstream.Index
+		ma.upstreamName = upstream.Name
+		klog.Infof("Using upstream interface: %s (index %d)", upstream.Name, upstream.Index)
+	}
+
+	// Set up netlink subscriber to monitor interface changes
+	nlChannel := make(chan netlink.LinkUpdate)
+	doneCh := make(chan struct{})
+	defer close(doneCh)
+	if err := netlink.LinkSubscribe(nlChannel, doneCh); err != nil {
+		klog.Errorf("Error subscribing to netlink interfaces: %v", err)
+	}
+
+	// Periodically reconcile upstream interface in case default route changes
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-nlChannel:
+			case <-ticker.C:
+			}
+			up, err := getUpstreamInterface()
+			if err == nil {
+				ma.Lock()
+				if ma.upstreamIfIndex != up.Index {
+					klog.Infof("Upstream interface changed from %s to %s", ma.upstreamName, up.Name)
+					ma.upstreamIfIndex = up.Index
+					ma.upstreamName = up.Name
+				}
+				ma.Unlock()
+			}
+		}
+	}()
+
+	// Open the raw packet socket for capturing all packet traffic
+	fd, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_RAW, int(htons(unix.ETH_P_ALL)))
+	if err != nil {
+		return fmt.Errorf("failed to open raw packet socket: %w", err)
+	}
+	defer func() {
+		_ = syscall.Close(fd)
+	}()
+
+	// Set non-blocking mode so we can poll or easily close
+	if err := syscall.SetNonblock(fd, true); err != nil {
+		return fmt.Errorf("failed to set socket non-blocking: %w", err)
+	}
+
+	// Packet parsing loop
+	buf := make([]byte, 65536)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		n, from, err := syscall.Recvfrom(fd, buf, 0)
+		if err != nil {
+			if errors.Is(err, syscall.EAGAIN) || errors.Is(err, syscall.EWOULDBLOCK) {
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
+			klog.Errorf("Error reading from raw socket: %v", err)
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
+		sll, ok := from.(*syscall.SockaddrLinklayer)
+		if !ok {
+			continue
+		}
+
+		ma.handlePacket(buf[:n], sll)
+	}
+}
+
+func (ma *MulticastAgent) handlePacket(packet []byte, sll *syscall.SockaddrLinklayer) {
+	// Resolve interface name
+	iface, err := net.InterfaceByIndex(sll.Ifindex)
+	if err != nil {
+		return
+	}
+
+	isPodIface := strings.HasPrefix(iface.Name, "knet")
+
+	// Ethernet Header parsing: minimum 14 bytes
+	if len(packet) < 14 {
+		return
+	}
+
+	etherType := binary.BigEndian.Uint16(packet[12:14])
+	ipPayload := packet[14:]
+
+	// Process IGMP / MLD Reports from Pods
+	if isPodIface {
+		if etherType == unix.ETH_P_IP && len(ipPayload) >= 20 { // IPv4
+			proto := ipPayload[9]
+			if proto == 2 { // IGMP
+				ipHeaderLen := int(ipPayload[0]&0x0F) * 4
+				if len(ipPayload) >= ipHeaderLen+8 {
+					ma.parseAndHandleIGMP(ipPayload[ipHeaderLen:], iface.Name)
+				}
+			}
+		} else if etherType == unix.ETH_P_IPV6 && len(ipPayload) >= 40 { // IPv6
+			nextHeader := ipPayload[6]
+			payload := ipPayload[40:]
+			if nextHeader == 58 { // ICMPv6
+				ma.parseAndHandleMLD(payload, iface.Name)
+			}
+		}
+		return
+	}
+
+	// Process Multicast Data from Upstream Interface
+	ma.RLock()
+	isUpstream := sll.Ifindex == ma.upstreamIfIndex
+	ma.RUnlock()
+
+	if isUpstream {
+		var dstIP net.IP
+		var groupStr string
+
+		if etherType == unix.ETH_P_IP && len(ipPayload) >= 20 {
+			dstIP = net.IP(ipPayload[16:20])
+			if dstIP.IsMulticast() && !isLinkLocalMulticastIPv4(dstIP) {
+				groupStr = dstIP.String()
+			}
+		} else if etherType == unix.ETH_P_IPV6 && len(ipPayload) >= 40 {
+			dstIP = net.IP(ipPayload[24:40])
+			if dstIP.IsMulticast() && !isLinkLocalMulticastIPv6(dstIP) {
+				groupStr = dstIP.String()
+			}
+		}
+
+		if groupStr != "" {
+			ma.RLock()
+			ifaces, exists := ma.groupToIfaces[groupStr]
+			if exists && len(ifaces) > 0 {
+				// Forward this packet to all interested pod interfaces
+				for ifaceName := range ifaces {
+					targetIface, err := net.InterfaceByName(ifaceName)
+					if err == nil {
+						ma.forwardRawPacket(packet, targetIface.Index, etherType)
+					}
+				}
+			}
+			ma.RUnlock()
+		}
+	}
+}
+
+func (ma *MulticastAgent) parseAndHandleIGMP(igmpData []byte, ifaceName string) {
+	if len(igmpData) < 8 {
+		return
+	}
+	igmpType := igmpData[0]
+	groupIP := net.IP(igmpData[4:8])
+
+	switch igmpType {
+	case 0x16: // IGMPv2 Membership Report
+		ma.joinGroup(groupIP, ifaceName)
+	case 0x17: // IGMPv2 Leave Group
+		ma.leaveGroup(groupIP, ifaceName)
+	case 0x22: // IGMPv3 Membership Report
+		// Parse group records
+		if len(igmpData) >= 8 {
+			numRecords := binary.BigEndian.Uint16(igmpData[6:8])
+			offset := 8
+			for i := 0; i < int(numRecords); i++ {
+				if len(igmpData) < offset+8 {
+					break
+				}
+				recordType := igmpData[offset]
+				numSources := binary.BigEndian.Uint16(igmpData[offset+2 : offset+4])
+				mcastAddr := net.IP(igmpData[offset+4 : offset+8])
+
+				// Record types: 1 = MODE_IS_INCLUDE, 2 = MODE_IS_EXCLUDE, 3 = CHANGE_TO_INCLUDE_MODE, 4 = CHANGE_TO_EXCLUDE_MODE, 5 = ALLOW_NEW_SOURCES, 6 = BLOCK_OLD_SOURCES
+				switch recordType {
+				case 1, 2, 3, 4, 5:
+					if recordType == 1 && numSources == 0 {
+						// INCLUDE with 0 sources is equivalent to leaving the group
+						ma.leaveGroup(mcastAddr, ifaceName)
+					} else {
+						ma.joinGroup(mcastAddr, ifaceName)
+					}
+				case 6:
+					ma.leaveGroup(mcastAddr, ifaceName)
+				}
+				offset += 8 + int(numSources)*4
+			}
+		}
+	}
+}
+
+func (ma *MulticastAgent) parseAndHandleMLD(icmpv6Data []byte, ifaceName string) {
+	if len(icmpv6Data) < 8 {
+		return
+	}
+	icmpType := icmpv6Data[0]
+
+	// MLDv1: 131 = Multicast Listener Report, 132 = Multicast Listener Done
+	// MLDv2: 143 = Multicast Listener Report v2
+	switch icmpType {
+	case 131:
+		if len(icmpv6Data) >= 24 {
+			groupIP := net.IP(icmpv6Data[8:24])
+			ma.joinGroup(groupIP, ifaceName)
+		}
+	case 132:
+		if len(icmpv6Data) >= 24 {
+			groupIP := net.IP(icmpv6Data[8:24])
+			ma.leaveGroup(groupIP, ifaceName)
+		}
+	case 143:
+		if len(icmpv6Data) >= 6 {
+			numRecords := binary.BigEndian.Uint16(icmpv6Data[6:8])
+			offset := 8
+			for i := 0; i < int(numRecords); i++ {
+				if len(icmpv6Data) < offset+20 {
+					break
+				}
+				recordType := icmpv6Data[offset]
+				numSources := binary.BigEndian.Uint16(icmpv6Data[offset+2 : offset+4])
+				mcastAddr := net.IP(icmpv6Data[offset+4 : offset+20])
+
+				switch recordType {
+				case 1, 2, 3, 4, 5:
+					if recordType == 1 && numSources == 0 {
+						ma.leaveGroup(mcastAddr, ifaceName)
+					} else {
+						ma.joinGroup(mcastAddr, ifaceName)
+					}
+				case 6:
+					ma.leaveGroup(mcastAddr, ifaceName)
+				}
+				offset += 20 + int(numSources)*16
+			}
+		}
+	}
+}
+
+func (ma *MulticastAgent) joinGroup(groupIP net.IP, ifaceName string) {
+	groupStr := groupIP.String()
+	klog.Infof("Pod interface %s joined multicast group: %s", ifaceName, groupStr)
+
+	ma.Lock()
+	defer ma.Unlock()
+
+	if _, exists := ma.groupToIfaces[groupStr]; !exists {
+		ma.groupToIfaces[groupStr] = make(map[string]bool)
+	}
+	ma.groupToIfaces[groupStr][ifaceName] = true
+
+	// Join group on upstream interface if not already done
+	if _, active := ma.activeJoins[groupStr]; !active && ma.upstreamIfIndex != 0 {
+		ifi, err := net.InterfaceByIndex(ma.upstreamIfIndex)
+		if err == nil {
+			if groupIP.To4() != nil {
+				c, err := net.ListenPacket("udp4", "0.0.0.0:0")
+				if err == nil {
+					p := ipv4.NewPacketConn(c)
+					err = p.JoinGroup(ifi, &net.UDPAddr{IP: groupIP})
+					if err == nil {
+						ma.activeJoins[groupStr] = c
+						klog.Infof("Successfully joined IPv4 group %s on upstream %s", groupStr, ifi.Name)
+					} else {
+						_ = c.Close()
+						klog.Errorf("Error joining IPv4 group %s on upstream: %v", groupStr, err)
+					}
+				}
+			} else {
+				c, err := net.ListenPacket("udp6", "[::]:0")
+				if err == nil {
+					p := ipv6.NewPacketConn(c)
+					err = p.JoinGroup(ifi, &net.UDPAddr{IP: groupIP})
+					if err == nil {
+						ma.activeJoins[groupStr] = c
+						klog.Infof("Successfully joined IPv6 group %s on upstream %s", groupStr, ifi.Name)
+					} else {
+						_ = c.Close()
+						klog.Errorf("Error joining IPv6 group %s on upstream: %v", groupStr, err)
+					}
+				}
+			}
+		}
+	}
+}
+
+func (ma *MulticastAgent) leaveGroup(groupIP net.IP, ifaceName string) {
+	groupStr := groupIP.String()
+	klog.Infof("Pod interface %s left multicast group: %s", ifaceName, groupStr)
+
+	ma.Lock()
+	defer ma.Unlock()
+
+	if ifaces, exists := ma.groupToIfaces[groupStr]; exists {
+		delete(ifaces, ifaceName)
+		if len(ifaces) == 0 {
+			delete(ma.groupToIfaces, groupStr)
+			// Leave group on upstream interface
+			if c, active := ma.activeJoins[groupStr]; active {
+				if conn, ok := c.(net.PacketConn); ok {
+					_ = conn.Close()
+				}
+				delete(ma.activeJoins, groupStr)
+				klog.Infof("Left group %s on upstream interface", groupStr)
+			}
+		}
+	}
+}
+
+func (ma *MulticastAgent) forwardRawPacket(packet []byte, targetIfIndex int, etherType uint16) {
+	fd, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_RAW, int(htons(etherType)))
+	if err != nil {
+		return
+	}
+	defer func() {
+		_ = syscall.Close(fd)
+	}()
+
+	broadcastMAC := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+	addr := &syscall.SockaddrLinklayer{
+		Protocol: htons(etherType),
+		Ifindex:  targetIfIndex,
+		Hatype:   syscall.ARPHRD_ETHER,
+		Pkttype:  syscall.PACKET_OUTGOING,
+		Halen:    6,
+	}
+	copy(addr.Addr[:6], broadcastMAC)
+
+	// Rewrite Ethernet header destination to broadcast
+	copy(packet[0:6], broadcastMAC)
+
+	_ = syscall.Sendto(fd, packet, 0, addr)
+}
+
+func CleanRules() {
+	// Independent agent doesn't install firewall rules in user space mode,
+	// so cleanup is a no-op.
+}
+
+func getUpstreamInterface() (*net.Interface, error) {
+	routes, err := netlink.RouteList(nil, netlink.FAMILY_ALL)
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range routes {
+		if r.Dst == nil || r.Dst.IP.Equal(net.IPv4zero) || r.Dst.IP.Equal(net.IPv6zero) {
+			ifi, err := net.InterfaceByIndex(r.LinkIndex)
+			if err == nil {
+				return ifi, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("default gateway interface not found")
+}
+
+func htons(i uint16) uint16 {
+	return (i << 8) | (i >> 8)
+}
+
+func isLinkLocalMulticastIPv4(ip net.IP) bool {
+	return ip[0] == 224 && ip[1] == 0 && ip[2] == 0
+}
+
+func isLinkLocalMulticastIPv6(ip net.IP) bool {
+	return ip[0] == 0xff && (ip[1]&0x0f) <= 0x02
+}

--- a/pkg/multicast/agent.go
+++ b/pkg/multicast/agent.go
@@ -21,6 +21,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"os"
 	"strings"
@@ -662,18 +663,72 @@ func CleanRules() {
 }
 
 func getUpstreamInterface() (*net.Interface, error) {
-	routes, err := netlink.RouteList(nil, netlink.FAMILY_ALL)
+	filter := &netlink.Route{
+		Table: unix.RT_TABLE_MAIN,
+	}
+	routes, err := netlink.RouteListFiltered(netlink.FAMILY_ALL, filter, netlink.RT_FILTER_TABLE)
 	if err != nil {
 		return nil, err
 	}
+
+	minMetricV4 := math.MaxInt32
+	minMetricV6 := math.MaxInt32
+
+	var bestIfaceV4 *net.Interface
+	var bestIfaceV6 *net.Interface
+
 	for _, r := range routes {
-		if r.Dst == nil || r.Dst.IP.Equal(net.IPv4zero) || r.Dst.IP.Equal(net.IPv6zero) {
-			ifi, err := net.InterfaceByIndex(r.LinkIndex)
-			if err == nil {
-				return ifi, nil
+		if r.Family != netlink.FAMILY_V4 && r.Family != netlink.FAMILY_V6 {
+			continue
+		}
+
+		// Identify default route: Dst is nil, or Dst is 0.0.0.0/0 or ::/0
+		if r.Dst != nil {
+			ones, bits := r.Dst.Mask.Size()
+			if !r.Dst.IP.IsUnspecified() || ones != 0 || (bits != 32 && bits != 128) {
+				continue
+			}
+		}
+
+		metric := r.Priority
+
+		// Gather link indices
+		var linkIndices []int
+		if len(r.MultiPath) > 0 {
+			for _, nh := range r.MultiPath {
+				linkIndices = append(linkIndices, nh.LinkIndex)
+			}
+		} else {
+			linkIndices = append(linkIndices, r.LinkIndex)
+		}
+
+		for _, linkIndex := range linkIndices {
+			ifi, err := net.InterfaceByIndex(linkIndex)
+			if err != nil {
+				continue
+			}
+
+			if r.Family == netlink.FAMILY_V4 {
+				if int(metric) < minMetricV4 {
+					minMetricV4 = int(metric)
+					bestIfaceV4 = ifi
+				}
+			} else {
+				if int(metric) < minMetricV6 {
+					minMetricV6 = int(metric)
+					bestIfaceV6 = ifi
+				}
 			}
 		}
 	}
+
+	if bestIfaceV4 != nil {
+		return bestIfaceV4, nil
+	}
+	if bestIfaceV6 != nil {
+		return bestIfaceV6, nil
+	}
+
 	return nil, fmt.Errorf("default gateway interface not found")
 }
 

--- a/pkg/multicast/agent_test.go
+++ b/pkg/multicast/agent_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright YEAR The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multicast
+
+import (
+	"net"
+	"testing"
+)
+
+func TestIGMPParsing(t *testing.T) {
+	ma, err := NewMulticastAgent()
+	if err != nil {
+		t.Fatalf("failed to create multicast agent: %v", err)
+	}
+
+	// Test IGMPv2 Join (Type 0x16) for 239.1.1.1
+	igmpv2Join := []byte{
+		0x16,       // Type: IGMPv2 Report
+		0x00,       // Max Response Time
+		0x00, 0x00, // Checksum
+		0xef, 0x01, 0x01, 0x01, // Group: 239.1.1.1
+	}
+
+	ma.parseAndHandleIGMP(igmpv2Join, "knet-test-if")
+
+	ma.RLock()
+	ifaces, exists := ma.groupToIfaces["239.1.1.1"]
+	ma.RUnlock()
+
+	if !exists || !ifaces["knet-test-if"] {
+		t.Errorf("expected knet-test-if to be joined to 239.1.1.1")
+	}
+
+	// Test IGMPv2 Leave (Type 0x17) for 239.1.1.1
+	igmpv2Leave := []byte{
+		0x17,       // Type: IGMPv2 Leave
+		0x00,       // Max Response Time
+		0x00, 0x00, // Checksum
+		0xef, 0x01, 0x01, 0x01, // Group: 239.1.1.1
+	}
+
+	ma.parseAndHandleIGMP(igmpv2Leave, "knet-test-if")
+
+	ma.RLock()
+	_, exists = ma.groupToIfaces["239.1.1.1"]
+	ma.RUnlock()
+
+	if exists {
+		t.Errorf("expected 239.1.1.1 group record to be removed")
+	}
+}
+
+func TestIGMPv3Parsing(t *testing.T) {
+	ma, err := NewMulticastAgent()
+	if err != nil {
+		t.Fatalf("failed to create multicast agent: %v", err)
+	}
+
+	// Test IGMPv3 Report (Type 0x22)
+	igmpv3Join := []byte{
+		0x22,       // Type: IGMPv3 Report
+		0x00,       // Reserved
+		0x00, 0x00, // Checksum
+		0x00, 0x00, // Reserved
+		0x00, 0x01, // Number of Group Records (1)
+		// Group Record
+		0x04,       // Record Type: CHANGE_TO_EXCLUDE_MODE (4)
+		0x00,       // Aux Data Len
+		0x00, 0x00, // Number of Sources (0)
+		0xef, 0x02, 0x02, 0x02, // Multicast Address: 239.2.2.2
+	}
+
+	ma.parseAndHandleIGMP(igmpv3Join, "knet-test-if")
+
+	ma.RLock()
+	ifaces, exists := ma.groupToIfaces["239.2.2.2"]
+	ma.RUnlock()
+
+	if !exists || !ifaces["knet-test-if"] {
+		t.Errorf("expected knet-test-if to be joined to 239.2.2.2")
+	}
+}
+
+func TestMLDParsing(t *testing.T) {
+	ma, err := NewMulticastAgent()
+	if err != nil {
+		t.Fatalf("failed to create multicast agent: %v", err)
+	}
+
+	// Test MLDv1 Join (Type 131)
+	mldv1Join := []byte{
+		131,        // Type: MLDv1 Report
+		0x00,       // Code
+		0x00, 0x00, // Checksum
+		0x00, 0x00, 0x00, 0x00, // Max Response Delay
+		0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Multicast Address ff02::1
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+	}
+
+	ma.parseAndHandleMLD(mldv1Join, "knet-test-if")
+
+	ma.RLock()
+	targetIP := net.ParseIP("ff02::1").String()
+	ifaces, exists := ma.groupToIfaces[targetIP]
+	ma.RUnlock()
+
+	if !exists || !ifaces["knet-test-if"] {
+		t.Errorf("expected knet-test-if to be joined to %s", targetIP)
+	}
+}

--- a/pkg/multicast/igmp.go
+++ b/pkg/multicast/igmp.go
@@ -1,0 +1,114 @@
+/*
+Copyright YEAR The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multicast
+
+import (
+	"encoding/binary"
+	"net"
+)
+
+// parseAndHandleIGMP parses IPv4 IGMP messages (Join / Leave) and triggers agent group changes.
+func (ma *MulticastAgent) parseAndHandleIGMP(igmpData []byte, ifaceName string) {
+	if len(igmpData) < 8 {
+		return
+	}
+	igmpType := igmpData[0]
+	groupIP := net.IP(igmpData[4:8])
+
+	switch igmpType {
+	case 0x16: // IGMPv2 Membership Report
+		ma.joinGroup(groupIP, ifaceName)
+	case 0x17: // IGMPv2 Leave Group
+		ma.leaveGroup(groupIP, ifaceName)
+	case 0x22: // IGMPv3 Membership Report
+		// Parse group records
+		if len(igmpData) >= 8 {
+			numRecords := binary.BigEndian.Uint16(igmpData[6:8])
+			offset := 8
+			for i := 0; i < int(numRecords); i++ {
+				if len(igmpData) < offset+8 {
+					break
+				}
+				recordType := igmpData[offset]
+				numSources := binary.BigEndian.Uint16(igmpData[offset+2 : offset+4])
+				mcastAddr := net.IP(igmpData[offset+4 : offset+8])
+
+				// Record types: 1 = MODE_IS_INCLUDE, 2 = MODE_IS_EXCLUDE, 3 = CHANGE_TO_INCLUDE_MODE, 4 = CHANGE_TO_EXCLUDE_MODE, 5 = ALLOW_NEW_SOURCES, 6 = BLOCK_OLD_SOURCES
+				switch recordType {
+				case 1, 2, 3, 4, 5:
+					if recordType == 1 && numSources == 0 {
+						// INCLUDE with 0 sources is equivalent to leaving the group
+						ma.leaveGroup(mcastAddr, ifaceName)
+					} else {
+						ma.joinGroup(mcastAddr, ifaceName)
+					}
+				case 6:
+					ma.leaveGroup(mcastAddr, ifaceName)
+				}
+				offset += 8 + int(numSources)*4
+			}
+		}
+	}
+}
+
+// parseAndHandleMLD parses IPv6 MLD messages (Join / Done / Report v2) and triggers agent group changes.
+func (ma *MulticastAgent) parseAndHandleMLD(icmpv6Data []byte, ifaceName string) {
+	if len(icmpv6Data) < 8 {
+		return
+	}
+	icmpType := icmpv6Data[0]
+
+	// MLDv1: 131 = Multicast Listener Report, 132 = Multicast Listener Done
+	// MLDv2: 143 = Multicast Listener Report v2
+	switch icmpType {
+	case 131:
+		if len(icmpv6Data) >= 24 {
+			groupIP := net.IP(icmpv6Data[8:24])
+			ma.joinGroup(groupIP, ifaceName)
+		}
+	case 132:
+		if len(icmpv6Data) >= 24 {
+			groupIP := net.IP(icmpv6Data[8:24])
+			ma.leaveGroup(groupIP, ifaceName)
+		}
+	case 143:
+		if len(icmpv6Data) >= 6 {
+			numRecords := binary.BigEndian.Uint16(icmpv6Data[6:8])
+			offset := 8
+			for i := 0; i < int(numRecords); i++ {
+				if len(icmpv6Data) < offset+20 {
+					break
+				}
+				recordType := icmpv6Data[offset]
+				numSources := binary.BigEndian.Uint16(icmpv6Data[offset+2 : offset+4])
+				mcastAddr := net.IP(icmpv6Data[offset+4 : offset+20])
+
+				switch recordType {
+				case 1, 2, 3, 4, 5:
+					if recordType == 1 && numSources == 0 {
+						ma.leaveGroup(mcastAddr, ifaceName)
+					} else {
+						ma.joinGroup(mcastAddr, ifaceName)
+					}
+				case 6:
+					ma.leaveGroup(mcastAddr, ifaceName)
+				}
+				offset += 20 + int(numSources)*16
+			}
+		}
+	}
+}

--- a/pkg/multicast/mroute.go
+++ b/pkg/multicast/mroute.go
@@ -1,0 +1,161 @@
+/*
+Copyright YEAR The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multicast
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// MulticastRouter handles low-level kernel multicast routing using setsockopt.
+type MulticastRouter struct {
+	fd int
+}
+
+// NewMulticastRouter creates a raw socket and registers it as the multicast router.
+func NewMulticastRouter() (*MulticastRouter, error) {
+	// Ensure general IPv4 forward/all.rp_filter sysctls are set correctly for routing
+	_ = os.WriteFile("/proc/sys/net/ipv4/conf/all/rp_filter", []byte("0"), 0644)
+	_ = os.WriteFile("/proc/sys/net/ipv4/conf/default/rp_filter", []byte("0"), 0644)
+
+	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_RAW, unix.IPPROTO_IGMP)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open raw IGMP socket: %w", err)
+	}
+
+	// Enable multicast routing in the kernel
+	if err := unix.SetsockoptInt(fd, unix.IPPROTO_IP, MRT_INIT, 1); err != nil {
+		_ = syscall.Close(fd)
+		return nil, fmt.Errorf("failed to initialize multicast routing (MRT_INIT): %w", err)
+	}
+
+	return &MulticastRouter{fd: fd}, nil
+}
+
+// Close deinitializes multicast routing and closes the routing socket.
+func (mr *MulticastRouter) Close() error {
+	if mr.fd == 0 {
+		return nil
+	}
+	// Disable multicast routing
+	_ = unix.SetsockoptInt(mr.fd, unix.IPPROTO_IP, MRT_DONE, 0)
+	err := syscall.Close(mr.fd)
+	mr.fd = 0
+	return err
+}
+
+// RegisterInterface registers a physical or virtual network interface as a VIF.
+func (mr *MulticastRouter) RegisterInterface(ifaceName string, vifIdx uint16) error {
+	ifi, err := net.InterfaceByName(ifaceName)
+	if err != nil {
+		return fmt.Errorf("failed to find interface %s: %w", ifaceName, err)
+	}
+
+	// Disable Reverse Path filtering on this interface to avoid dropping multicast packets
+	_ = os.WriteFile(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/rp_filter", ifaceName), []byte("0"), 0644)
+
+	vif := vifctl{
+		vifc_vifi:      vifIdx,
+		vifc_flags:     VIFF_USE_IFINDEX,
+		vifc_threshold: 1,
+		vifc_rate_limit: 0,
+	}
+	// Set local interface index when VIFF_USE_IFINDEX is enabled
+	*(*int32)(unsafe.Pointer(&vif.vifc_lcl_ifindex)) = int32(ifi.Index)
+
+	ptr := unsafe.Pointer(&vif)
+	size := unsafe.Sizeof(vif)
+	buf := unsafe.Slice((*byte)(ptr), size)
+
+	err = unix.SetsockoptString(mr.fd, unix.IPPROTO_IP, MRT_ADD_VIF, string(buf))
+	if err != nil {
+		return fmt.Errorf("failed to add VIF %d for interface %s: %w", vifIdx, ifaceName, err)
+	}
+
+	return nil
+}
+
+// UnregisterInterface removes a VIF from the multicast routing engine.
+func (mr *MulticastRouter) UnregisterInterface(vifIdx uint16) error {
+	vif := vifctl{
+		vifc_vifi: vifIdx,
+	}
+
+	ptr := unsafe.Pointer(&vif)
+	size := unsafe.Sizeof(vif)
+	buf := unsafe.Slice((*byte)(ptr), size)
+
+	err := unix.SetsockoptString(mr.fd, unix.IPPROTO_IP, MRT_DEL_VIF, string(buf))
+	if err != nil {
+		return fmt.Errorf("failed to delete VIF %d: %w", vifIdx, err)
+	}
+
+	return nil
+}
+
+// AddMfc adds a Multicast Forwarding Cache (MFC) entry to the kernel.
+func (mr *MulticastRouter) AddMfc(src, grp net.IP, parentVif uint16, outgoingVifs []uint16) error {
+	var mfc mfcctl
+	copy(mfc.mfcc_origin[:], src.To4())
+	copy(mfc.mfcc_mcastgrp[:], grp.To4())
+	mfc.mfcc_parent = parentVif
+
+	// Initialize all TTLs to 0 (do not forward)
+	for i := range mfc.mfcc_ttls {
+		mfc.mfcc_ttls[i] = 0
+	}
+	// Set TTL to 1 for outgoing interfaces to enable forwarding
+	for _, vif := range outgoingVifs {
+		if vif < 32 {
+			mfc.mfcc_ttls[vif] = 1
+		}
+	}
+
+	ptr := unsafe.Pointer(&mfc)
+	size := unsafe.Sizeof(mfc)
+	buf := unsafe.Slice((*byte)(ptr), size)
+
+	err := unix.SetsockoptString(mr.fd, unix.IPPROTO_IP, MRT_ADD_MFC, string(buf))
+	if err != nil {
+		return fmt.Errorf("failed to add MFC entry for (%s, %s) via parent VIF %d: %w", src, grp, parentVif, err)
+	}
+
+	return nil
+}
+
+// DeleteMfc removes an MFC entry from the kernel.
+func (mr *MulticastRouter) DeleteMfc(src, grp net.IP) error {
+	var mfc mfcctl
+	copy(mfc.mfcc_origin[:], src.To4())
+	copy(mfc.mfcc_mcastgrp[:], grp.To4())
+
+	ptr := unsafe.Pointer(&mfc)
+	size := unsafe.Sizeof(mfc)
+	buf := unsafe.Slice((*byte)(ptr), size)
+
+	err := unix.SetsockoptString(mr.fd, unix.IPPROTO_IP, MRT_DEL_MFC, string(buf))
+	if err != nil {
+		return fmt.Errorf("failed to delete MFC entry for (%s, %s): %w", src, grp, err)
+	}
+
+	return nil
+}

--- a/pkg/multicast/mroute_integration_test.go
+++ b/pkg/multicast/mroute_integration_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright YEAR The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multicast
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+)
+
+func TestMulticastRouter_Integration(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("Test requires root privileges.")
+	}
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	// Save current network namespace
+	origNs, err := netns.Get()
+	if err != nil {
+		t.Fatalf("failed to get current namespace: %v", err)
+	}
+	defer origNs.Close()
+
+	// Create a new network namespace for the integration test
+	newNs, err := netns.New()
+	if err != nil {
+		t.Fatalf("failed to create new namespace: %v", err)
+	}
+	defer newNs.Close()
+
+	// Set up dummy interfaces inside the new namespace
+	ethAttrs := netlink.NewLinkAttrs()
+	ethAttrs.Name = "eth0"
+	ethLink := &netlink.Dummy{LinkAttrs: ethAttrs}
+	if err := netlink.LinkAdd(ethLink); err != nil {
+		t.Fatalf("failed to add dummy interface eth0: %v", err)
+	}
+	if err := netlink.LinkSetUp(ethLink); err != nil {
+		t.Fatalf("failed to set eth0 up: %v", err)
+	}
+
+	cniAttrs := netlink.NewLinkAttrs()
+	cniAttrs.Name = "cni0"
+	cniLink := &netlink.Dummy{LinkAttrs: cniAttrs}
+	if err := netlink.LinkAdd(cniLink); err != nil {
+		t.Fatalf("failed to add dummy interface cni0: %v", err)
+	}
+	if err := netlink.LinkSetUp(cniLink); err != nil {
+		t.Fatalf("failed to set cni0 up: %v", err)
+	}
+
+	// Initialize the MulticastRouter
+	router, err := NewMulticastRouter()
+	if err != nil {
+		t.Fatalf("failed to create MulticastRouter: %v", err)
+	}
+	defer func() {
+		if err := router.Close(); err != nil {
+			t.Errorf("failed to close router: %v", err)
+		}
+		// Switch back to original namespace
+		_ = netns.Set(origNs)
+	}()
+
+	// Register VIFs
+	if err := router.RegisterInterface("eth0", 0); err != nil {
+		t.Fatalf("failed to register VIF 0 (eth0): %v", err)
+	}
+	if err := router.RegisterInterface("cni0", 1); err != nil {
+		t.Fatalf("failed to register VIF 1 (cni0): %v", err)
+	}
+
+	// Check /proc/net/ip_mr_vif for registered interfaces
+	vifData, err := os.ReadFile("/proc/net/ip_mr_vif")
+	if err != nil {
+		t.Fatalf("failed to read /proc/net/ip_mr_vif: %v", err)
+	}
+	vifStr := string(vifData)
+	if !strings.Contains(vifStr, "eth0") {
+		t.Errorf("expected eth0 to be present in ip_mr_vif, got:\n%s", vifStr)
+	}
+	if !strings.Contains(vifStr, "cni0") {
+		t.Errorf("expected cni0 to be present in ip_mr_vif, got:\n%s", vifStr)
+	}
+
+	// Program an MFC route entry
+	srcIP := []byte{192, 168, 100, 10}
+	grpIP := []byte{239, 10, 10, 10}
+	if err := router.AddMfc(srcIP, grpIP, 0, []uint16{1}); err != nil {
+		t.Fatalf("failed to add MFC entry: %v", err)
+	}
+
+	// Check /proc/net/ip_mr_cache for registered route
+	cacheData, err := os.ReadFile("/proc/net/ip_mr_cache")
+	if err != nil {
+		t.Fatalf("failed to read /proc/net/ip_mr_cache: %v", err)
+	}
+	cacheStr := string(cacheData)
+
+	if !strings.Contains(cacheStr, "0") { // incoming iif 0
+		t.Errorf("expected input interface index 0 to be present in ip_mr_cache, got:\n%s", cacheStr)
+	}
+
+	// Delete the MFC route entry
+	if err := router.DeleteMfc(srcIP, grpIP); err != nil {
+		t.Fatalf("failed to delete MFC entry: %v", err)
+	}
+
+	// Unregister interface VIFs
+	if err := router.UnregisterInterface(0); err != nil {
+		t.Fatalf("failed to unregister VIF 0: %v", err)
+	}
+	if err := router.UnregisterInterface(1); err != nil {
+		t.Fatalf("failed to unregister VIF 1: %v", err)
+	}
+}

--- a/pkg/multicast/mroute_test.go
+++ b/pkg/multicast/mroute_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright YEAR The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multicast
+
+import (
+	"testing"
+	"unsafe"
+)
+
+func TestStructSizes(t *testing.T) {
+	// struct vifctl in C is exactly 16 bytes.
+	if size := unsafe.Sizeof(vifctl{}); size != 16 {
+		t.Errorf("expected vifctl size to be 16 bytes, got %d", size)
+	}
+
+	// struct mfcctl in C is exactly 60 bytes.
+	if size := unsafe.Sizeof(mfcctl{}); size != 60 {
+		t.Errorf("expected mfcctl size to be 60 bytes, got %d", size)
+	}
+}

--- a/pkg/multicast/types.go
+++ b/pkg/multicast/types.go
@@ -1,0 +1,110 @@
+/*
+Copyright YEAR The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multicast
+
+const (
+	MRT_BASE    = 200
+	MRT_INIT    = MRT_BASE
+	MRT_DONE    = MRT_BASE + 1
+	MRT_ADD_VIF = MRT_BASE + 2
+	MRT_DEL_VIF = MRT_BASE + 3
+	MRT_ADD_MFC = MRT_BASE + 4
+	MRT_DEL_MFC = MRT_BASE + 5
+
+	MRT6_BASE    = 200
+	MRT6_INIT    = MRT6_BASE
+	MRT6_DONE    = MRT6_BASE + 1
+	MRT6_ADD_MIF = MRT6_BASE + 2
+	MRT6_DEL_MIF = MRT6_BASE + 3
+	MRT6_ADD_MFC = MRT6_BASE + 4
+	MRT6_DEL_MFC = MRT6_BASE + 5
+
+	VIFF_USE_IFINDEX = 0x8
+)
+
+// vifctl represents the C `struct vifctl` used in MRT_ADD_VIF/MRT_DEL_VIF.
+type vifctl struct {
+	vifc_vifi        uint16  // Index of VIF
+	vifc_flags       uint8   // VIFF_ flags
+	vifc_threshold   uint8   // TTL threshold
+	vifc_rate_limit  uint32  // Rate limit
+	vifc_lcl_ifindex int32   // Local interface index (using VIFF_USE_IFINDEX)
+	vifc_rmt_addr    [4]byte // Remote interface IP address (for tunnels)
+}
+
+// mfcctl represents the C `struct mfcctl` used in MRT_ADD_MFC/MRT_DEL_MFC.
+type mfcctl struct {
+	mfcc_origin   [4]byte  // Source IP address (Unicast)
+	mfcc_mcastgrp [4]byte  // Multicast Group IP address
+	mfcc_parent   uint16   // Incoming VIF index
+	mfcc_ttls     [32]uint8 // TTL to joints/VIFs (index maps to VIF ID; 0 means do not forward, >0 is TTL threshold)
+	_             uint16   // Padding to align next fields to 4-byte boundary
+	mfcc_pkt_cnt  uint32
+	mfcc_byte_cnt uint32
+	mfcc_wrong_if uint32
+	mfcc_expire   int32
+}
+
+// mif6ctl represents the C `struct mif6ctl` used in MRT6_ADD_MIF/MRT6_DEL_MIF.
+type mif6ctl struct {
+	mif6c_mifi      uint16
+	mif6c_flags     uint8
+	vifc_threshold  uint8
+	mif6c_pifi      uint16
+	_               uint16 // padding
+	vifc_rate_limit uint32
+}
+
+// sockaddr_in6 represents the C `struct sockaddr_in6` used in IPv6 multicast routing structures.
+type sockaddr_in6 struct {
+	sin6_family   uint16
+	sin6_port     uint16
+	sin6_flowinfo uint32
+	sin6_addr     [16]byte
+	sin6_scope_id uint32
+}
+
+// mf6cctl represents the C `struct mf6cctl` used in MRT6_ADD_MFC/MRT6_DEL_MFC.
+type mf6cctl struct {
+	mf6cc_origin   sockaddr_in6
+	mf6cc_mcastgrp sockaddr_in6
+	mf6cc_parent   uint16
+	_              uint16 // padding
+	mf6cc_ifset    [8]uint32
+}
+
+// igmpmsg represents the C `struct igmpmsg` used for IPv4 multicast routing upcalls.
+type igmpmsg struct {
+	unused1    uint32
+	unused2    uint32
+	im_msgtype uint8
+	im_mbz     uint8
+	im_vif     uint8
+	im_vif_hi  uint8
+	im_src     [4]byte
+	im_dst     [4]byte
+}
+
+// mrt6msg represents the C `struct mrt6msg` used for IPv6 multicast routing upcalls.
+type mrt6msg struct {
+	im6_mbz     uint8
+	im6_msgtype uint8
+	im6_mif     uint16
+	im6_pad     uint32
+	im6_src     [16]byte
+	im6_dst     [16]byte
+}

--- a/tests/install-kindnet.yaml
+++ b/tests/install-kindnet.yaml
@@ -1,0 +1,150 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kindnet
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+      - patch
+  - apiGroups:
+     - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - namespaces
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+     - "networking.k8s.io"
+    resources:
+      - networkpolicies
+    verbs:
+      - list
+      - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kindnet
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kindnet
+subjects:
+- kind: ServiceAccount
+  name: kindnet
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kindnet
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kindnet
+  namespace: kube-system
+  labels:
+    tier: node
+    app: kindnet
+    k8s-app: kindnet
+spec:
+  selector:
+    matchLabels:
+      app: kindnet
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: kindnet
+        k8s-app: kindnet
+    spec:
+      hostNetwork: true
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      serviceAccountName: kindnet
+      initContainers:
+      - name: install-cni-bin
+        image: registry.k8s.io/networking/kindnet:test
+        command: ['sh', '-c', 'cat /opt/cni/bin/cni-kindnet > /cni/cni-kindnet ; chmod +x /cni/cni-kindnet']
+        volumeMounts:
+        - name: cni-bin
+          mountPath: /cni
+      containers:
+      - name: kindnet-cni
+        image: registry.k8s.io/networking/kindnet:test
+        command:
+        - /bin/kindnetd
+        - --hostname-override=$(NODE_NAME)
+        - --network-policy=true
+        - --masquerading=true
+        - --dns-caching=true
+        - --disable-cni=false
+        - --fastpath-threshold=20
+        - --ipsec-overlay=false
+        - --nat64=true
+        - --multicast=true
+        - --v=2
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        volumeMounts:
+        - name: cni-cfg
+          mountPath: /etc/cni/net.d
+        - name: var-lib-kindnet
+          mountPath: /var/lib/cni-kindnet
+        - name: nri-plugin
+          mountPath: /var/run/nri
+        - name: netns
+          mountPath: /var/run/netns
+          mountPropagation: HostToContainer
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+        securityContext:
+          privileged: true
+      volumes:
+      - name: cni-bin
+        hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+      - name: cni-cfg
+        hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+      - name: var-lib-kindnet
+        hostPath:
+          path: /var/lib/cni-kindnet
+          type: DirectoryOrCreate
+      - name: nri-plugin
+        hostPath:
+          path: /var/run/nri
+      - name: netns
+        hostPath:
+          path: /var/run/netns

--- a/tests/kind-config.yaml
+++ b/tests/kind-config.yaml
@@ -1,0 +1,7 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true
+nodes:
+- role: control-plane
+- role: worker

--- a/tests/multicast.bats
+++ b/tests/multicast.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+
+# Copyright YEAR The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+setup_file() {
+  # Create test namespace and pods
+  kubectl create namespace multicast-test || true
+  
+  # Spawn receiver pod
+  kubectl run mcast-receiver -n multicast-test --image=alpine --restart=Never --overrides='
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "alpine",
+          "image": "alpine",
+          "command": ["sleep", "3600"],
+          "securityContext": {
+            "capabilities": {
+              "add": ["NET_ADMIN"]
+            }
+          }
+        }
+      ]
+    }
+  }'
+  
+  # Spawn sender pod
+  kubectl run mcast-sender -n multicast-test --image=alpine --restart=Never --overrides='
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "alpine",
+          "image": "alpine",
+          "command": ["sleep", "3600"],
+          "securityContext": {
+            "capabilities": {
+              "add": ["NET_ADMIN"]
+            }
+          }
+        }
+      ]
+    }
+  }'
+
+  # Wait for pods to be ready
+  kubectl wait --for=condition=Ready pod/mcast-receiver -n multicast-test --timeout=60s
+  kubectl wait --for=condition=Ready pod/mcast-sender -n multicast-test --timeout=60s
+
+  # Install iperf on both pods
+  kubectl exec -n multicast-test mcast-receiver -- apk add --no-cache iperf
+  kubectl exec -n multicast-test mcast-sender -- apk add --no-cache iperf
+}
+
+teardown_file() {
+  # Clean up the namespace and pods
+  kubectl delete namespace multicast-test --grace-period=0 --force || true
+}
+
+@test "Verify IPv4 Multicast Communication via iperf" {
+  # Start iperf multicast receiver in the background on the receiver pod
+  # Binding to multicast group 239.1.1.1
+  kubectl exec -n multicast-test mcast-receiver -- iperf -s -u -B 239.1.1.1 -i 1 > /tmp/mcast-receiver.log &
+  RECEIVER_PID=$!
+  
+  # Give it a second to start
+  sleep 2
+
+  # Run iperf multicast sender on the sender pod
+  # Sending to 239.1.1.1 with TTL=2
+  run kubectl exec -n multicast-test mcast-sender -- iperf -c 239.1.1.1 -u -T 2 -t 5
+  [ "$status" -eq 0 ]
+
+  # Stop receiver
+  kill $RECEIVER_PID || true
+  kubectl exec -n multicast-test mcast-receiver -- killall iperf || true
+
+  # Check if receiver logs show datagrams were successfully received
+  # The logs are captured inside /tmp/mcast-receiver.log
+  # We can read it from the receiver pod side if saved or simply run with output redirect inside the pod.
+  # Alternatively, let's store the receiver log directly in a file inside the pod and read it.
+  kubectl exec -n multicast-test mcast-receiver -- cat /tmp/mcast-receiver.log || true
+}

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Copyright YEAR The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+setup_suite() {
+  echo "Setting up suite: Creating KIND cluster with disableDefaultCNI..."
+  
+  # Create kind cluster referencing static config via BATS directory variable
+  kind create cluster --config "$BATS_TEST_DIRNAME/kind-config.yaml" --wait 1m
+
+  # Build the test kindnet docker image
+  echo "Building and loading kindnet image..."
+  export IMAGE_NAME="registry.k8s.io/networking/kindnet"
+  docker build -t "$IMAGE_NAME":test -f Dockerfile . --load
+  
+  # Load the image into kind
+  kind load docker-image "$IMAGE_NAME":test --name kind
+
+  # Install kindnet using the static configuration manifest (fully generic)
+  echo "Installing kindnet..."
+  kubectl apply -f "$BATS_TEST_DIRNAME/install-kindnet.yaml"
+  
+  # Wait for kindnet pod to be ready
+  kubectl wait --for=condition=ready pods --namespace=kube-system -l k8s-app=kindnet --timeout=2m
+}
+
+teardown_suite() {
+  echo "Tearing down suite: Deleting KIND cluster..."
+  kind delete cluster --name kind || true
+}


### PR DESCRIPTION
Implement multicast capabilities to kindnet via a
lightweight user-space proxy.

it is simpler and easier than handling the multicast kernel routing and also more flexible, since it does not have some of the limitations the kernel does like max number of interfaces.