### PR TITLE
Update NewRemoteRuntimeService signature

### DIFF
--- a/pkg/node/cri.go
+++ b/pkg/node/cri.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	remote "k8s.io/cri-client/pkg"
-	"k8s.io/klog/v2"
 )
 
 const (
@@ -37,10 +36,10 @@ var (
 )
 
 func getRuntimeService(timeout time.Duration) (res internalapi.RuntimeService, err error) {
-	logger := klog.Background()
+	ctx := context.Background()
 	if RuntimeEndpoint == "" {
 		for _, endPoint := range defaultRuntimeEndpoints {
-			res, err = remote.NewRemoteRuntimeService(endPoint, timeout, nil, &logger)
+			res, err = remote.NewRemoteRuntimeService(ctx, endPoint, timeout, nil, false)
 			if err != nil {
 				continue
 			}
@@ -49,7 +48,7 @@ func getRuntimeService(timeout time.Duration) (res internalapi.RuntimeService, e
 		}
 		return res, err
 	}
-	return remote.NewRemoteRuntimeService(RuntimeEndpoint, timeout, nil, &logger)
+	return remote.NewRemoteRuntimeService(ctx, RuntimeEndpoint, timeout, nil, false)
 }
 
 func getPodsIPs() (map[string][]string, error) {


### PR DESCRIPTION
Note: this is targeting the dependabot update branch to be included with the newer k8s updates as they need to be included together to pass.