### PR TITLE
Bump golangci-lint to v2.12.2

### DIFF
--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-VERSION=v2.7.2
+VERSION=v2.12.2
 
 cd $REPO_ROOT
 docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:${VERSION} golangci-lint run -v


### PR DESCRIPTION
Newer version of Go is causing issues running the current golangci-lint, built with Go 1.25. This raises the version of golangci-lint to the current latest release, built with Go 1.26.