### PR TITLE
Fix Grafana tutorial: add missing scrape config and clarify helm repo step

### DIFF
--- a/site/content/docs/tutorial/grafana/grafana-prometheus-kindnet-scrape-config.yaml
+++ b/site/content/docs/tutorial/grafana/grafana-prometheus-kindnet-scrape-config.yaml
@@ -1,0 +1,19 @@
+# Helm values for kube-prometheus-stack chart
+# Configures Prometheus to scrape kindnet metrics via the kindnet-metrics service
+
+prometheus:
+  prometheusSpec:
+    additionalScrapeConfigs:
+      - job_name: kindnet
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+          - role: endpoints
+            namespaces:
+              names:
+                - kube-system
+        relabelings:
+          - source_labels: [__meta_kubernetes_service_name]
+            action: keep
+            regex: kindnet-metrics
+          - target_label: __address__
+            replacement: kindnet-metrics.kube-system.svc:19080

--- a/site/content/docs/tutorial/grafana/index.md
+++ b/site/content/docs/tutorial/grafana/index.md
@@ -10,6 +10,7 @@ In this tutorial, we will guide you through the process of setting up a Grafana 
 Before you begin, ensure you have the following tools installed on your local machine:
 - **Docker Desktop**: Required to run Kubernetes clusters locally.
 - **kind**: A tool for running local Kubernetes clusters using Docker container nodes. You can install it by following the instructions on the [kind website](https://kind.sigs.k8s.io).
+- **Helm**: A package manager for Kubernetes. You can install it by following the instructions on the [Helm website](https://helm.sh/docs/intro/install/).
 
 ## Steps
 
@@ -35,10 +36,16 @@ kubectl label configmap kindnet-dashboards grafana_dashboard=1 -n monitoring
 
 **4. Install and configure `Grafana` and `Prometheus`**
 
+First, add the required Helm repositories:
+
 ```bash
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add grafana https://grafana.github.io/helm-charts
 helm repo update
+```
+
+Then install the `kube-prometheus-stack` chart using the [scrape configuration](grafana-prometheus-kindnet-scrape-config.yaml) that tells Prometheus to collect metrics from the `kindnet-metrics` service:
+
+```bash
 helm install monitoring prometheus-community/kube-prometheus-stack --namespace monitoring --values grafana-prometheus-kindnet-scrape-config.yaml
 ```
 


### PR DESCRIPTION
## What this PR does

Fixes the Grafana tutorial that was broken because the referenced `grafana-prometheus-kindnet-scrape-config.yaml` file did not exist.

### Changes:

1. **Add `grafana-prometheus-kindnet-scrape-config.yaml`**: The tutorial referenced this values file but it was missing. This file configures Prometheus (via `kube-prometheus-stack` chart's `additionalScrapeConfigs`) to scrape metrics from the `kindnet-metrics` service on port 19080.

2. **Clarify helm repo setup**: Split the helm repo setup and helm install into separate code blocks with explanatory text, so users understand they must run `helm repo add` before `helm install`.

3. **Remove unnecessary `helm repo add grafana`**: Grafana is bundled as a subchart in `kube-prometheus-stack`, so the separate grafana repo is not needed.

4. **Add Helm to prerequisites**: Helm was not listed in the prerequisites section.

Ref: #129

```release-note
NONE
```